### PR TITLE
修正

### DIFF
--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -3,7 +3,7 @@ class HomesController < ApplicationController
 
   def top
     @posts = Post.all.order(created_at: "DESC").page(params[:page]).per(3)
-    @tags = Tag.all
+    @tags = Tag.all.select{ |tag| tag.posts.count != 0 }
   end
 
   def about

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -12,6 +12,8 @@ before_action :correct_customer, only: [:edit, :update]
   def create
     @post = current_customer.posts.new(post_params)
     tag_list = params[:post][:name].split(',')
+    tag_list << params[:post][:prefecture_id]
+    tag_list << params[:post][:city]
     if @post.save
       @post.save_tag(tag_list)
       flash[:notice] = "投稿に成功しました。"

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -23,8 +23,8 @@
         <td colspan="4"><%= link_to @post.customer.nickname, customer_path(@post.customer_id) %></td>
       </tr>
       <tr>
-        <th>タグ</th>
-        <td colspan="5">
+        <th colspan="2">タグ</th>
+        <td colspan="4">
           <% @post_tags.each do |post_tag| %>
             <%= link_to post_tag.name + "(#{post_tag.posts.count})", posts_path(sort: "tag", tag: "#{post_tag.name}") %>/
           <% end %>
@@ -51,12 +51,12 @@
         <td colspan="4"><%= @post.capacity %></td>
       </tr>
       <tr>
-        <th>会場</th>
-        <td colspan="5"><%= @post.place %></td>
+        <th colspan="2">会場</th>
+        <td colspan="4"><%= @post.place %></td>
       </tr>
       <tr>
-        <th>内容</th>
-        <td colspan="5"><%= simple_format(@post.body) %></td>
+        <th colspan="2">内容</th>
+        <td colspan="4"><%= simple_format(@post.body) %></td>
       </tr>
     </tbody>
   </table>

--- a/app/views/team_records/show.html.erb
+++ b/app/views/team_records/show.html.erb
@@ -33,8 +33,8 @@
           <td colspan="4"<%= @team_record.result %>></td>
         </tr>
         <tr>
-          <th>内容</th>
-          <td colspan="5"><%= simple_format(@team_record.note) %></td>
+          <th colspan="2">内容</th>
+          <td colspan="4"><%= simple_format(@team_record.note) %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/teams/index.html.erb
+++ b/app/views/teams/index.html.erb
@@ -16,12 +16,12 @@
             <p class="card-text">
               <div class="d-flex">
                 <div class="mr-5">
-                  代表者　　：<%= Customer.find(team.owner_id).nickname %><br>
-                  エリア　　：<%= team.prefecture_id %><<%= team.city %><br>
+                  代表者：<%= Customer.find(team.owner_id).nickname %><br>
+                  エリア：<%= team.prefecture_id %><<%= team.city %><br>
                   メンバー数：<%= team.member_count %>
                 </div>
 
-                <div>
+                <div class="d-none d-sm-block">
                   <%= image_tag team.get_team_image("100x100"), class:"ml-md-5" %>
                 </div>
               </div>

--- a/app/views/teams/new.html.erb
+++ b/app/views/teams/new.html.erb
@@ -16,21 +16,21 @@
             <%= f.text_field :city, class:"form-control mt-3", placeholder:"市区町村" %>
 
             <%= f.label :"メンバー数", class:"mt-3" %>
-            <%= f.text_field :member_count, class:"form-control" %>
+            <%= f.text_field :member_count, class:"form-control", placeholder: "例)15人" %>
 
             <%= f.label :"年代", class:"mt-3" %>
-            <%= f.text_field :age, class:"form-control" %>
+            <%= f.text_field :age, class:"form-control", placeholder: "例)20代~30代" %>
 
 
           </div>
 
           <div class="col-md-6">
 
-            <%= f.label :"レベル", class:"mt-3" %>
-         　  <%= f.text_field :level, class:"form-control" %>
+            <%= f.label :"レベル(10段階)", class:"mt-3" %>
+         　  <%= f.text_field :level, class:"form-control", placeholder: "例)6~7" %>
 
             <%= f.label :"活動日時", class:"mt-3" %>
-            <%= f.text_field :activities_time, class:"form-control" %>
+            <%= f.text_field :activities_time, class:"form-control", placeholder: "例)毎週土曜日朝9時" %>
 
             <%= f.label :"創立年", class:"mt-3" %>
             <%= f.text_field :founded, class:"form-control" %>


### PR DESCRIPTION
・投稿作成時、活動エリアもタグに追加されるように仕様変更
・投稿詳細ページレイアウト修正
・投稿が0の場合はタグ一覧にタグを表示しないように修正
・チーム一覧のチーム画像を携帯画面では非表示にする
